### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: stable
+          go-version: 1.26.x
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: stable
+          go-version: 1.26.x
       - name: Download Go modules
         run: go mod download
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,11 +19,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: stable
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: v2.1
           only-new-issues: true
           args: --timeout=5m
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
 
         with:
-          go-version: stable
+          go-version: 1.26.x
       - uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.gh_pat }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthieugusmini/rift
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/internal/lolesportsgraphql/client_test.go
+++ b/internal/lolesportsgraphql/client_test.go
@@ -44,9 +44,9 @@ func TestClient_GetStage(t *testing.T) {
 		assert.Equal(t, "semifinal-1", semifinal.StructuralID)
 		require.NotNil(t, semifinal.Destinations)
 		assert.Equal(t, lolesportsgraphql.DestinationTypeMatch, semifinal.Destinations.Win.Type)
-		assert.Equal(t, pointer("final"), semifinal.Destinations.Win.StructuralID)
+		assert.Equal(t, new("final"), semifinal.Destinations.Win.StructuralID)
 		require.NotNil(t, semifinal.Teams[0].Result)
-		assert.Equal(t, pointer("win"), semifinal.Teams[0].Result.Outcome)
+		assert.Equal(t, new("win"), semifinal.Teams[0].Result.Outcome)
 
 		final := stage.Sections[0].Columns[1].Cells[0].Matches[0]
 		assert.Nil(t, final.Destinations)
@@ -165,8 +165,4 @@ func assertGetStageRequest(t *testing.T, r *http.Request, stageID string) {
 		"1b5a17d767e7b415b56d2319238468791089bc25cb782138697ae5eefbbea668",
 		extensions.PersistedQuery.Hash,
 	)
-}
-
-func pointer[T any](value T) *T {
-	return &value
 }

--- a/internal/rift/lolesports_loader_test.go
+++ b/internal/rift/lolesports_loader_test.go
@@ -226,7 +226,7 @@ var testStandings = []lolesports.Standings{
 										Code:  "M5",
 										Image: "https://le-link-pour-get-l-image.com",
 										Result: &lolesports.Result{
-											Outcome:  pointer("win"),
+											Outcome:  new("win"),
 											GameWins: 3,
 										},
 									},
@@ -289,5 +289,3 @@ func (c *stubLoLEsportsAPIClient) GetSchedule(
 ) (lolesports.Schedule, error) {
 	return lolesports.Schedule{}, nil
 }
-
-func pointer[T any](v T) *T { return &v }

--- a/internal/ui/dynamic_bracket_test.go
+++ b/internal/ui/dynamic_bracket_test.go
@@ -306,7 +306,7 @@ func matchAdvancingTo(structuralID, destinationID string) lolesportsgraphql.Matc
 	match.Destinations = &lolesportsgraphql.Destinations{
 		Win: lolesportsgraphql.Destination{
 			Type:         lolesportsgraphql.DestinationTypeMatch,
-			StructuralID: pointer(destinationID),
+			StructuralID: new(destinationID),
 		},
 	}
 
@@ -329,7 +329,7 @@ func matchAdvancingToWinAndLoss(
 	match := matchAdvancingTo(structuralID, winDestinationID)
 	match.Destinations.Loss = lolesportsgraphql.Destination{
 		Type:         lolesportsgraphql.DestinationTypeMatch,
-		StructuralID: pointer(lossDestinationID),
+		StructuralID: new(lossDestinationID),
 	}
 
 	return match
@@ -394,8 +394,4 @@ func dynamicEdgeExists(
 	}
 
 	return false
-}
-
-func pointer[T any](value T) *T {
-	return &value
 }


### PR DESCRIPTION
## Summary
- require Go 1.26 for local builds and releases
- pin CI jobs to the latest Go 1.26 patch release
- use Go 1.26 `new(value)` expressions instead of test pointer helpers

## Dependency
- stacked on #90

## Validation
- `go test -race ./...`
- `go build ./...`
- `golangci-lint run --new-from-rev=feature/dynamic-stage-data`
- `go fix -newexpr -diff ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`